### PR TITLE
Add SendLog to loki client

### DIFF
--- a/connector/loki.go
+++ b/connector/loki.go
@@ -117,6 +117,13 @@ func (client *LokiClient) Start() {
     }()
 }
 
+func (client *LokiClient) SendLog(labels map[string]string, message string, timestamp time.Duration) {
+    m := Message {
+        Message: message,
+        Time: timestamp,
+    }
+    client.AddStream(labels, []Message{m})
+}
 
 // The template for the message sent to Loki is:
 //{


### PR DESCRIPTION
SendLog() queues one log for sending to loki. This is needed, so the loki client implements the Sender interface in Lokean