### PR TITLE
Change logging package in config/ini.go

### DIFF
--- a/config/ini.go
+++ b/config/ini.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/go-ini/ini"
-	"github.com/paramite/collectd-sensubility/logging"
+	"github.com/infrawatch/apputils/logging"
 )
 
 const (


### PR DESCRIPTION
Using paramite/collectd-sensubility/logging package in config/ini.go prevents from using logging package from apputils in NewConfig()