### PR TITLE
Add SetLevel() and SetFile() to logging

### DIFF
--- a/logging/logger.go
+++ b/logging/logger.go
@@ -50,6 +50,21 @@ func (self *Logger) Metadata(metadata map[string]interface{}) {
 	self.metadata = metadata
 }
 
+func(self *Logger) SetLogLevel(level LogLevel) {
+    self.Level = level
+}
+
+func(self *Logger) SetFile(path string) error {
+    newLogfile, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+    if err != nil {
+        self.Warn("Couldn't open new log file, leaving the old one")
+        return err
+    }
+    self.logfile.Close()
+    self.logfile = newLogfile
+    return nil
+}
+
 func (self *Logger) formatMetadata() (string, error) {
 	//var build strings.Builder
 	// Note: we need to support go-1.9.2 because of CentOS7

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -51,18 +51,18 @@ func (self *Logger) Metadata(metadata map[string]interface{}) {
 }
 
 func(self *Logger) SetLogLevel(level LogLevel) {
-    self.Level = level
+	self.Level = level
 }
 
-func(self *Logger) SetFile(path string) error {
-    newLogfile, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-    if err != nil {
-        self.Warn("Couldn't open new log file, leaving the old one")
-        return err
-    }
-    self.logfile.Close()
-    self.logfile = newLogfile
-    return nil
+func(self *Logger) SetFile(path string, permissions os.FileMode) error {
+	newLogfile, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_APPEND, permissions)
+	if err != nil {
+		self.Warn("Couldn't open new log file, leaving the old one")
+		return err
+	}
+	self.logfile.Close()
+	self.logfile = newLogfile
+	return nil
 }
 
 func (self *Logger) formatMetadata() (string, error) {


### PR DESCRIPTION
There is a cyclic dependency, when you want to read log level and log file from config file. For creating a logger, you need to know the log level and log file. For reading a config file, you need a logger.

With these functions, we can create a logger with some default values, use that to read the log level and log file from config file and then set the proper values in the logger.