### PR TITLE
Add test for logging.SetFile()

### DIFF
--- a/tests/logging_test.go
+++ b/tests/logging_test.go
@@ -53,6 +53,7 @@ func TestLogger(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	logpath := path.Join(tmpdir, "test.log")
+	logpath2 := path.Join(tmpdir, "test2.log")
 	log, err := logging.NewLogger(logging.DEBUG, logpath)
 	if err != nil {
 		t.Fatalf("Failed to create logger: %s", err)
@@ -179,6 +180,56 @@ func TestLogger(t *testing.T) {
 			t.Fatalf("Failed to fetch last line in log file: %s", err)
 		}
 		assert.Equal(t, "[ERROR] Test error 4\n", actual)
+	})
+
+	t.Run("Test SetFile", func(t *testing.T) {
+		log.Level = logging.ERROR
+
+		lastInFile1, err := getLastLineWithSeek(logpath)
+		if err != nil {
+			t.Fatalf("Failed to fetch last line in log file: %s", err)
+		}
+
+		err = log.SetFile(logpath2, 0666)
+		if err != nil {
+			t.Fatalf("Failed switching log files: %s", err)
+		}
+		log.Error("Test SetFile")
+
+		actualInFile1, err := getLastLineWithSeek(logpath)
+		if err != nil {
+			t.Fatalf("Failed to fetch last line in log file: %s", err)
+		}
+
+		assert.Equal(t, lastInFile1, actualInFile1)
+
+		actualInFile2, err := getLastLineWithSeek(logpath2)
+		if err != nil {
+			t.Fatalf("Failed to fetch last line in log file: %s", err)
+		}
+
+		assert.Equal(t, "[ERROR] Test SetFile\n", actualInFile2)
+
+		// change it back
+		err = log.SetFile(logpath, 0666)
+		if err != nil {
+			t.Fatalf("Failed switching log files: %s", err)
+		}
+		log.Error("Test SetFile2")
+
+		actualInFile1, err = getLastLineWithSeek(logpath)
+		if err != nil {
+			t.Fatalf("Failed to fetch last line in log file: %s", err)
+		}
+
+		assert.Equal(t, "[ERROR] Test SetFile2\n", actualInFile1)
+
+		actualInFile2, err = getLastLineWithSeek(logpath2)
+		if err != nil {
+			t.Fatalf("Failed to fetch last line in log file: %s", err)
+		}
+
+		assert.Equal(t, "[ERROR] Test SetFile\n", actualInFile2)
 	})
 
 	t.Run("Test metadata", func(t *testing.T) {


### PR DESCRIPTION
I forgot to add a test for SetFile() yesterday. I was also thinking about adding a test for SetLogLevel(), but I figured out, it's unnecessary, because it only sets one variable and that same variable gets set multiple times during testing. I could add it if anyone thinks it's a good idea.