### PR TITLE
Make loki more like other connectors

### DIFF
--- a/connector/amqp10.go
+++ b/connector/amqp10.go
@@ -58,27 +58,27 @@ func NewAMQP10Connector(cfg config.Config, logger *logging.Logger) (*AMQP10Conne
 			return &connector, fmt.Errorf("Failed to get client name from configuration file at amqp1/client_name: %s", err)
 		}
 	case *config.JSONConfig:
-		if addr, err := conf.GetOption("Amqp1.Connection.Address"); err == nil {
+		if addr, err := conf.GetOption("Amqp1.Connection.Address"); err == nil && addr != nil {
 			connector.Address = addr.GetString()
 		} else {
 			return &connector, fmt.Errorf("Failed to get connection URL from configuration file at Amqp1.Connection.Address: %s", err)
 		}
-		if sendTimeout, err := conf.GetOption("Amqp1.Connection.SendTimeout"); err == nil {
+		if sendTimeout, err := conf.GetOption("Amqp1.Connection.SendTimeout"); err == nil && sendTimeout != nil {
 			connector.SendTimeout = sendTimeout.GetInt()
 		} else {
 			return &connector, fmt.Errorf("Failed to get send timeout from configuration file at Amqp1.Connection.SendTimeout: %s", err)
 		}
-		if listen, err := conf.GetOption("Amqp1.Connection.ListenChannels"); err == nil {
+		if listen, err := conf.GetOption("Amqp1.Connection.ListenChannels"); err == nil && listen != nil {
 			prefetch := int64(-1)
 			prf, err := conf.GetOption("Amqp1.Connection.ListenPrefetch")
-			if err == nil {
+			if err == nil && prf != nil {
 				prefetch = prf.GetInt()
 			}
 			for _, channel := range listen.GetStrings(",") {
 				connector.CreateReceiver(channel, int(prefetch))
 			}
 		}
-		if clientName, err := conf.GetOption("Amqp1.Client.Name"); err == nil {
+		if clientName, err := conf.GetOption("Amqp1.Client.Name"); err == nil && clientName != nil {
 			connector.ClientName = clientName.GetString()
 		} else {
 			return &connector, fmt.Errorf("Failed to get client name from configuration file at Amqp1.Client.Name: %s", err)

--- a/connector/loki.go
+++ b/connector/loki.go
@@ -98,15 +98,15 @@ func NewLokiConnector(cfg config.Config, logger *logging.Logger) (*LokiConnector
 		} else {
 			return nil, fmt.Errorf("Failed to get connection URL from configuration file at loki/connection")
 		}
-		if batchSize, err := conf.GetOption("loki/batchSize"); err == nil {
+		if batchSize, err := conf.GetOption("loki/batch_size"); err == nil {
 			client.maxBatch = batchSize.GetInt()
 		} else {
-			return nil, fmt.Errorf("Failed to get connection max batch size from configuration file at loki/batchSize")
+			return nil, fmt.Errorf("Failed to get connection max batch size from configuration file at loki/batch_size")
 		}
-		if waitTime, err := conf.GetOption("loki/maxWaitTime"); err == nil {
+		if waitTime, err := conf.GetOption("loki/max_wait_time"); err == nil {
 			client.maxWaitTime = time.Duration(waitTime.GetInt()) * time.Millisecond
 		} else {
-			return nil, fmt.Errorf("Failed to get connection max wait time from configuration file at loki/maxWaitTime")
+			return nil, fmt.Errorf("Failed to get connection max wait time from configuration file at loki/max_wait_time")
 		}
 	case *config.JSONConfig:
 		if addr, err := conf.GetOption("Loki.Connection.Address"); err == nil {

--- a/connector/loki.go
+++ b/connector/loki.go
@@ -109,17 +109,17 @@ func NewLokiConnector(cfg config.Config, logger *logging.Logger) (*LokiConnector
 			return nil, fmt.Errorf("Failed to get connection max wait time from configuration file at loki/max_wait_time")
 		}
 	case *config.JSONConfig:
-		if addr, err := conf.GetOption("Loki.Connection.Address"); err == nil {
+		if addr, err := conf.GetOption("Loki.Connection.Address"); err == nil && addr != nil {
 			client.url = addr.GetString()
 		} else {
 			return nil, fmt.Errorf("Failed to get connection URL from configuration file at Loki.Connection.Address: %s", err)
 		}
-		if batchSize, err := conf.GetOption("Loki.Connection.BatchSize"); err == nil {
+		if batchSize, err := conf.GetOption("Loki.Connection.BatchSize"); err == nil && batchSize != nil {
 			client.maxBatch = batchSize.GetInt()
 		} else {
 			return nil, fmt.Errorf("Failed to get connection max batch size from configuration file at Loki.Connection.BatchSize: %s", err)
 		}
-		if waitTime, err := conf.GetOption("Loki.Connection.MaxWaitTime"); err == nil {
+		if waitTime, err := conf.GetOption("Loki.Connection.MaxWaitTime"); err == nil && waitTime != nil {
 			client.maxWaitTime = time.Duration(waitTime.GetInt()) * time.Millisecond
 		} else {
 			return nil, fmt.Errorf("Failed to get connection max wait time from configuration file at Loki.Connection.MaxWaitTime: %s", err)


### PR DESCRIPTION
I rewrote the connector to use `New*Connector(), Connect(), Start(), Disconnect()` like all of the other connectors. I also incorporated the apputils/logging and apputils/config

~~I am currently not sure what is the best way for this connector to receive logs before sending them to Loki. The JSON format, that is sent to Loki looks like this:~~

```
{
	"streams": [
	  {
		"stream": {
		  "label1": "value",
		  "label2": "value2"
		},
		"values": [
			[ "<unix epoch in nanoseconds>", "<log line>" ],
			[ "<unix epoch in nanoseconds>", "<log line>" ]
		]
	  },
	  {
		"stream": {
		  "label1": "value",
		  "label3": "value3"
		},
		"values": [
			[ "<unix epoch in nanoseconds>", "<log line>" ]
		]
	  }
            .........
	]
}

```
~~There is no restriction on how many streams can be sent at once, or how many labels or log messages there are in one stream.~~
~~Before this PR, there were 2 functions: AddStream(labels map[string]string, messages []Message), which allows to add a whole stream, but is not that easy to use, because an array of messages must be defined even if we want to send only one log.~~
~~Another function was: SendLog(labels map[string]string, message string, timestamp time.Duration), which is more convenient for sending only one log at a time, but cannot be used for sending more logs in one stream (this is currently used in lokean).~~

~~This PR adds func (client *LokiConnector) Start2(outchan chan interface(), inchan chan interface()), which uses channels like the other connectors and might eventually replace Start(), but I'm not sure what type to use on the inchan.~~

~~Do we expect to receive (from rsyslog or whatever else) multiple logs at once which would get assigned to the same set of labels and thus it would be useful to send multiple logs in one stream (we want to define the whole stream and put that on the inchan)? (similar to AddStream()) (This is currently implemented in Start2)~~

~~Or do we rather expect the logs to come relatively slowly or that each log will have different set of labels assigned and so it is better to just put one log at a time (along with timestamp and labels) on the channel? (similar to SendLog())~~