### PR TITLE
Process missing config sections

### DIFF
--- a/config/ini.go
+++ b/config/ini.go
@@ -46,6 +46,15 @@ func (conf INIConfig) Parse(path string) error {
 					return err
 				}
 			}
+		} else {
+			// default values for the whole section
+			for _, param := range sectionMetadata {
+				if opt, err := createOption(nil, param, conf.log); err == nil {
+					conf.Sections[sectionName].Options[param.Name] = opt
+				} else {
+					return err
+				}
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
This patch adds missing logic for case when whole config section
is missing in the config file.