### PR TITLE
[AMQP1.0] Connect before receiver gets created

### DIFF
--- a/system/signals.go
+++ b/system/signals.go
@@ -1,0 +1,26 @@
+package system
+
+import (
+	"os"
+	"os/signal"
+
+	"github.com/infrawatch/apputils/logging"
+)
+
+//SpawnSignalHandler spawns goroutine which will wait for given interruption signal(s)
+// and in case any is receiverend closes given channel to signal that program should be closed
+func SpawnSignalHandler(finish chan bool, logger *logging.Logger, watchedSignals ...os.Signal) {
+	interruptChannel := make(chan os.Signal, 1)
+	signal.Notify(interruptChannel, watchedSignals...)
+	go func() {
+	signalLoop:
+		for sig := range interruptChannel {
+			logger.Metadata(map[string]interface{}{
+				"signal": sig,
+			})
+			logger.Error("Stopping execution on caught signal")
+			close(finish)
+			break signalLoop
+		}
+	}()
+}


### PR DESCRIPTION
Connector has to be connected already before receiver is being created,
otherwise the piece of code is no-op or is erroring.