### PR TITLE
[AMQP1.0] Don't listen on empty address

### DIFF
--- a/connector/amqp10.go
+++ b/connector/amqp10.go
@@ -111,6 +111,9 @@ func ConnectAMQP10(cfg config.Config, logger *logging.Logger) (*AMQP10Connector,
 			prefetch = prf.GetInt()
 		}
 		for _, channel := range listen.GetStrings(",") {
+			if len(channel) < 1 {
+				continue
+			}
 			logger.Metadata(map[string]interface{}{
 				"channel":  channel,
 				"prefetch": prefetch,


### PR DESCRIPTION
This patch skips receiver creation when split returns empty string.