### PR TITLE
Split connector package into separate packages

### DIFF
--- a/connector/amqp10/amqp10.go
+++ b/connector/amqp10/amqp10.go
@@ -1,4 +1,4 @@
-package connector
+package amqp10
 
 import (
 	"fmt"

--- a/connector/loki/loki.go
+++ b/connector/loki/loki.go
@@ -1,4 +1,4 @@
-package connector
+package loki
 
 import (
 	"bytes"

--- a/connector/sensu/sensu.go
+++ b/connector/sensu/sensu.go
@@ -1,4 +1,4 @@
-package connector
+package sensu
 
 import (
 	"encoding/json"
@@ -18,6 +18,7 @@ const (
 	QueueNameResults     = "results"
 	defaultClientAddress = "127.0.0.1"
 	defaultInterval      = 30
+	defaultClientName     = "localhost"
 )
 
 //Result contains data about check execution

--- a/connector/unixSocket/unixSocket.go
+++ b/connector/unixSocket/unixSocket.go
@@ -1,4 +1,4 @@
-package connector
+package unixSocket
 
 import (
 	"fmt"


### PR DESCRIPTION
Having a big package for all connectors causes unnecessary dependencies when using the package, because dependencies for all of the connectors need to be satisfied, even if only one of them is used. By splitting the package into separate packages for each connector only the dependencies for each connector are required.

For example list of shared objects linked to loki application sg-core plugin before this change:
```
	linux-vdso.so.1 (0x00007fffc3fad000)
	libqpid-proton-core.so.10 => /lib64/libqpid-proton-core.so.10 (0x00007f1df07a7000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f1df0786000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f1df05b7000)
	libssl.so.1.1 => /lib64/libssl.so.1.1 (0x00007f1df051b000)
	libsasl2.so.3 => /lib64/libsasl2.so.3 (0x00007f1df04fb000)
	libcrypto.so.1.1 => /lib64/libcrypto.so.1.1 (0x00007f1df020d000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f1df1114000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007f1df0204000)
	libresolv.so.2 => /lib64/libresolv.so.2 (0x00007f1df01ea000)
	libcrypt.so.2 => /lib64/libcrypt.so.2 (0x00007f1df01b0000)
	libgssapi_krb5.so.2 => /lib64/libgssapi_krb5.so.2 (0x00007f1df0159000)
	libkrb5.so.3 => /lib64/libkrb5.so.3 (0x00007f1df007b000)
	libk5crypto.so.3 => /lib64/libk5crypto.so.3 (0x00007f1df0063000)
	libcom_err.so.2 => /lib64/libcom_err.so.2 (0x00007f1df005a000)
	libz.so.1 => /lib64/libz.so.1 (0x00007f1df0040000)
	libkrb5support.so.0 => /lib64/libkrb5support.so.0 (0x00007f1df002f000)
	libkeyutils.so.1 => /lib64/libkeyutils.so.1 (0x00007f1df0028000)
	libselinux.so.1 => /lib64/libselinux.so.1 (0x00007f1defffc000)
	libpcre2-8.so.0 => /lib64/libpcre2-8.so.0 (0x00007f1deff63000)
```
After the change:
```
	linux-vdso.so.1 (0x00007ffeef5ef000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f4825842000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f4825673000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f4826172000)
```

(Hopefuly complete) list of files within infrawatch org, that use the connector package and will need to be updated:
```
lokean/tests/pkg/logs_test.go
lokean/pkg/sources/base.go
lokean/pkg/sources/rsyslog.go
lokean/cmd/main.go

sg-core/plugins/application/loki/pkg/lib/loki.go
sg-core/plugins/application/loki/main.go
sg-core/plugins/application/loki/main_test.go

collectd-sensubility/sensu/scheduler.go
collectd-sensubility/sensu/executor.go
collectd-sensubility/formats/sg.go
collectd-sensubility/main/main.go
```