### PR TITLE
Update unit tests job

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   test-framework:
     name: Unit test suite
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code
@@ -94,7 +94,7 @@ jobs:
       - name: Run unit tests
         run: |
           export PROJECT_ROOT=/root/go/src/github.com/infrawatch/apputils
-          docker run -uroot --network host --volume=${{ github.workspace }}:$PROJECT_ROOT:z --workdir $PROJECT_ROOT quay.io/centos/centos:stream8 bash ci/run_ci.sh
+          docker run -uroot --network host --volume=${{ github.workspace }}:$PROJECT_ROOT:z --workdir $PROJECT_ROOT quay.io/centos/centos:stream9 bash ci/run_ci.sh
       - name: List dependency containers' logs
         run: |
           echo "---- rabbitmq ----"


### PR DESCRIPTION
Ubuntu 20.04 images have been deprecated, so when the unit tests job is executed GH fails to find available runners.

Use Ubuntu 22.04 as base image for the unit tests job to fix this issue.

CentOS 8 Stream has also been deprecated. Use CentOS 9 Stream instead.